### PR TITLE
Fix #14 - Make Docker more flexible

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,7 @@ RUN curl --silent --output authzforce-ce-server.deb --location $AUTHZFORCE_SERVE
  rm -f authzforce-ce-server.deb
 
 VOLUME /opt/authzforce-ce-server/data
+VOLUME /usr/local/tomcat/conf
 
 CMD ["catalina.sh", "run"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,8 +68,10 @@ RUN curl --silent --output authzforce-ce-server.deb --location $AUTHZFORCE_SERVE
  rm -rf /opt/authzforce-ce-server/data/domains/* && \
  rm -rf /root/authzforce && \
  rm -f authzforce-ce-server.deb
+
+VOLUME /opt/authzforce-ce-server/data
+
 CMD ["catalina.sh", "run"]
 
 ### Exposed ports
-# - App server
-EXPOSE 8080
+EXPOSE ${AUTHZFORCE_PORT:-8080}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,4 +75,5 @@ VOLUME /usr/local/tomcat/conf
 CMD ["catalina.sh", "run"]
 
 ### Exposed ports
-EXPOSE ${AUTHZFORCE_PORT:-8080}
+# - App server
+EXPOSE 8080


### PR DESCRIPTION
* Expose Volume so Policies can be injected
* Remove hard-coded 8080 port and replace with optional `ENV` parameter in case port 8080 is in use. Port 8080 remains the default.